### PR TITLE
Load guava with only needed option to avoid loading SONATA

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,3 +1,4 @@
+LoadPackage( "guava" : OnlyNeeded ); # to avoid loading SONATA
 LoadPackage( "wedderga" );
 
 TestDirectory(DirectoriesPackageLibrary( "wedderga", "tst" ),


### PR DESCRIPTION
(see https://github.com/gap-system/gap/issues/2107)