### PR TITLE
Fix CI in the divalg branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
 branches:
   only:
     - master
+    - divalg
 
 before_script:
   - export GAPROOT="$HOME/gap"

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -17,7 +17,7 @@ SetPackageInfo( rec(
 PackageName    := "Wedderga",
 Subtitle       := Concatenation( [
                   "Wedderburn Decomposition of Group Algebras" ] ),
-Version        := "4.9.5-dev-divalg",
+Version        := "4.9.5-divalg-dev",
 Date           := "30/11/2018", # dd/mm/yyyy format
 License        := "GPL-2.0-or-later",
 ##  <#GAPDoc Label="PKGVERSIONDATA">


### PR DESCRIPTION
Taking two commits out of #59, as we need them earlier: they allow Travis CI to test pull requests to `divalg` branch, and modify package version to ensure that, if available, it has higher priority for loading, because of the version number ending with "dev".