### PR TITLE
Fix several bugs in ReducingCyclotomicAlgebra. 

### DIFF
--- a/lib/div-alg.gd
+++ b/lib/div-alg.gd
@@ -11,7 +11,7 @@
 # April 2020 - KillingCocycle, AntiSymMatUpMat,  added
 DeclareGlobalFunction("AntiSymMatUpMat");
 DeclareGlobalFunction("KillingCocycle");
-DeclareGlobalFunction("IsCyclotomicExtension");
+DeclareGlobalFunction("CyclotomicExtensionGenerator");
 DeclareGlobalFunction("ReducingCyclotomicAlgebra");
 ##
 DeclareGlobalFunction("PPartOfN");

--- a/lib/div-alg.gi
+++ b/lib/div-alg.gi
@@ -1399,20 +1399,21 @@ m:=1;
 B:=SimpleComponentOfGroupRingByCharacter(F,G,n);
 
 if Length(B)=2 then
-m:=1;
+  m:=1;
 fi;
 if Length(B)=4 then
-m:=LocalIndexAtOddP(B,p);
+  m:=LocalIndexAtOddP(B,p);
 fi;
 
 if Length(B)=5 then
-K:=PSplitSubextension(F,B[3],p);
-B1:=SimpleComponentOfGroupRingByCharacter(K,G,n);
-g:=DefiningGroupAndCharacterOfCyclotAlg(B1);
-m:=LocalIndexAtPByBrauerCharacter(K,g[1],g[2],p);
-#g:=DefiningGroupOfCyclotomicAlgebra(B1);
-#n1:=DefiningCharacterOfCyclotomicAlgebra(B1);
-#m:=LocalIndexAtPByBrauerCharacter(K,g,n1,p);
+  K:=PSplitSubextension(F,B[3],p);
+  B1:=SimpleComponentOfGroupRingByCharacter(K,G,n);
+  g:=DefiningGroupAndCharacterOfCyclotAlg(B1);
+  if g=fail then
+    m:=1;
+  else
+    m:=LocalIndexAtPByBrauerCharacter(K,g[1],g[2],p);
+  fi;
 fi;
 
 return m;
@@ -1446,44 +1447,45 @@ m2:=LocalIndexAtTwo(B);
 fi;
 
 if Length(B)=5 then
-K:=PSplitSubextension(F,B[3],2);
-B1:=SimpleComponentOfGroupRingByCharacter(K,G,n);
-g:=DefiningGroupAndCharacterOfCyclotAlg(B1);
-m2:=LocalIndexAtPByBrauerCharacter(K,g[1],g[2],2);
-#g:=DefiningGroupOfCyclotomicAlgebra(B1);
-#n1:=DefiningCharacterOfCyclotomicAlgebra(B1);
-#m2:=LocalIndexAtPByBrauerCharacter(F,g,n1,2);
-if not(m2 in Integers) then
-m:=1;
-  if IsDyadicSchurGroup(g[1]) then
-  m:=2;
-  V:=ValuesOfClassFunction(chi);
-  F0:=FieldByGenerators(V);
-  F1:=B1[2];
-    if not(F0=F1) then
-      if E(4) in F1 then
-        m:=1;
-      else
-        n0:=Conductor(F0);
-        n02:=PPartOfN(n0,2);
-        n1:=Conductor(F1);
-        n12:=PPartOfN(n1,2);
-          if not(n02=n12) then
-            m:=1;
-          else
-            n11:=PDashPartOfN(n1,2);
-            f1:=OrderMod(2,n1);
-            n01:=PDashPartOfN(n0,2);
-            f0:=OrderMod(2,n0);
-            f:=f1/f0;
-              if (f/2 in PositiveIntegers) then
-                m:=1;
-              fi;
-          fi;
-       fi;
+  K:=PSplitSubextension(F,B[3],2);
+  B1:=SimpleComponentOfGroupRingByCharacter(K,G,n);
+  g:=DefiningGroupAndCharacterOfCyclotAlg(B1);
+  if g=fail then
+    m2:=1;
+  else
+    m2:=LocalIndexAtPByBrauerCharacter(K,g[1],g[2],2);
+  fi;
+  if not(m2 in Integers) then
+    m:=1;
+    if IsDyadicSchurGroup(g[1]) then
+    m:=2;
+    V:=ValuesOfClassFunction(chi);
+    F0:=FieldByGenerators(V);
+    F1:=B1[2];
+      if not(F0=F1) then
+        if E(4) in F1 then
+          m:=1;
+        else
+          n0:=Conductor(F0);
+          n02:=PPartOfN(n0,2);
+          n1:=Conductor(F1);
+          n12:=PPartOfN(n1,2);
+            if not(n02=n12) then
+              m:=1;
+            else
+              n11:=PDashPartOfN(n1,2);
+              f1:=OrderMod(2,n1);
+              n01:=PDashPartOfN(n0,2);
+              f0:=OrderMod(2,n0);
+              f:=f1/f0;
+                if (f/2 in PositiveIntegers) then
+                  m:=1;
+                fi;
+            fi;
+         fi;
+      fi;
     fi;
   fi;
-fi;
 fi;
 
 if m>0 then m2:=m; fi;

--- a/lib/div-alg.gi
+++ b/lib/div-alg.gi
@@ -2341,11 +2341,11 @@ end);
 
 
 ################################################
-# IsCyclotomicExtension checks whether the input are two number fields 
+# CyclotomicExtensionGenerator checks whether the input are two number fields 
 # and the first is a cyclotomic extension of the second
 ################################################
 
-InstallGlobalFunction( IsCyclotomicExtension, function(K,F)
+InstallGlobalFunction( CyclotomicExtensionGenerator, function(K,F)
 
 local c,pr,e;
 
@@ -2397,7 +2397,7 @@ acon := List(acA,x->Filtered(Ucon,i->E(con)^i=E(con)^x)[1]);
 
 for x in [1..k] do
   F2:=NF(con,[acon[x]]);
-  c2:=IsCyclotomicExtension(F2,F);
+  c2:=CyclotomicExtensionGenerator(F2,F);
   if ForAll([1..k],j->e[x][j]=0) and c2<>0 then
     y := Difference([1..k],[x]);
     F1:=NF(con,List(y,j->acon[j]));
@@ -2522,9 +2522,9 @@ SortBy(gcls,Size);
 for x in gcls do
   y := Difference(v,x);
   F1:=NF(con,List(y,j->acon[j]));
-  c1 := IsCyclotomicExtension(F1,F);
+  c1 := CyclotomicExtensionGenerator(F1,F);
   F2:=NF(con,List(x,j->acon[j]));
-  c2 := IsCyclotomicExtension(F2,F);
+  c2 := CyclotomicExtensionGenerator(F2,F);
   if c1<>0 and c2<>0 then    
 
 # Construction of the first factor
@@ -2551,7 +2551,7 @@ for x in gcls do
         Print("\n The algebra is not a genuine cyclotomic algebra \n");
         return fail;
       fi;
-      Add(act,[A[4][i][1],acon[i] mod c1,ex]);                  
+      Add(act,[A[4][i][1],acon[i] mod c1,ex]);
       if pos < l then
         coc2 := [];
         for j in [pos+1..l] do
@@ -2588,7 +2588,7 @@ for x in gcls do
       coc1 := [];    
     fi;
     for i in y do
-      h:=E(con)^A[4][i][3];
+      h:=E(m)^A[4][i][3];
       a := 1;
       ex := 0;
       for j in [0..c2-1] do
@@ -2715,7 +2715,7 @@ for x in gcls do
   y := Difference(v,x);
   F1:=NF(con,List(y,j->A[4][j][2]));
   F2:=NF(con,List(x,j->A[4][j][2]));
-  if IsCyclotomicExtension(F2,F) and IsCyclotomicExtension(F2,F) then    
+  if CyclotomicExtensionGenerator(F2,F)<>0 and CyclotomicExtensionGenerator(F2,F)<>0 then    
 
 # Construction of the first factor
     c := Lcm(2,Conductor(F1));

--- a/lib/div-alg.gi
+++ b/lib/div-alg.gi
@@ -2340,38 +2340,33 @@ return [n,F,m,hrs,c];
 end);
 
 
-
-
-
-
-
-
-
-
 ################################################
 # IsCyclotomicExtension checks whether the input are two number fields 
 # and the first is a cyclotomic extension of the second
 ################################################
 
 InstallGlobalFunction( IsCyclotomicExtension, function(K,F)
-#IsCyclotomicExtension := function(K,F)
 
-local c,pr,i;
+local c,pr,e;
 
-if not IsNumberField(K) or not IsNumberField(F) or not IsSubset(K,F) then 
-  return fail;
+if not IsAbelianNumberField(K) or not IsAbelianNumberField(F) or not IsSubset(K,F) then 
+  return 0;
 fi;
 
-c:=Conductor(K);
-pr := PrimitiveElement(F);
+c:=Lcm(2,Conductor(K));
+e:=E(c);
 
-for i in [1..c] do
-  if Field([pr,E(i)])=K then 
-    return true;
-  fi;
+while not e in K do
+  e:=e*E(c);
 od;
 
-return false;
+pr := PrimitiveElement(F);
+
+if Field([pr,e])=K then 
+    return Order(e);
+else 
+  return 0;
+fi;
 
 end);
 
@@ -2380,9 +2375,8 @@ end);
 ################################################
 
 InstallGlobalFunction( ReducingCyclotomicAlgebra, function(A)
-#ReducingCyclotomicAlgebra := function(A)
 
-local m,e,F,pF,K,gal,con,Ucon,k,acA,acon,i,x,y,F1,F2,c,g,h,n,act,coc1,coc2,l,pos,ex,a,j,A1,split,v,w,d1,cls,gcls,lc,A2,s1,s2;
+local m,e,F,pF,K,gal,con,Ucon,k,acA,acon,i,x,y,F1,F2,c1,c2,c,g,h,n,act,coc1,coc2,l,pos,ex,a,j,A1,split,v,w,d1,cls,gcls,lc,A2,s1,s2;
 
 if Length(A) < 5 then
   return fail;
@@ -2403,32 +2397,34 @@ acon := List(acA,x->Filtered(Ucon,i->E(con)^i=E(con)^x)[1]);
 
 for x in [1..k] do
   F2:=NF(con,[acon[x]]);
-  if ForAll([1..k],j->e[x][j]=0) and IsCyclotomicExtension(F2,F) then
+  c2:=IsCyclotomicExtension(F2,F);
+  if ForAll([1..k],j->e[x][j]=0) and c2<>0 then
     y := Difference([1..k],[x]);
     F1:=NF(con,List(y,j->acon[j]));
 ## A is a tensor product of a cyclic algebra A1=(F1/F,a1) and a cyclotomic algebra A2=F2*H.
 ## We check whether a1 is the norm of a root of unity in F, so that A1 is split.
-    c := Lcm(2,Conductor(F1));
-    g := E(c);
+    c1 := Lcm(2,Conductor(F1));
+    g := E(c1);
     while not g in F1 do
-      g:=g*E(c);
+      g:=g*E(c1);
     od;
     h := E(m)^A[4][x][3];
-    n := Order(g);
+    c1 := Order(g);
     split := false;
     a := 1;
-    for i in [0..n-1] do
+    for i in [0..c1-1] do
       split := h=Norm(F1,F,a);
       if split then
         break;
       fi;
       a:=a*g;
     od;
-## If not we check whether A1 is cyclotomic and compute the Schur index of A1. 
-    if not split and IsCyclotomicExtension(F1,F) then
+## If not we check whether A1 is cyclotomic and in that case 
+## we check whether A1 it is split by verifying if its Schur index is 1 
+    if not split and F1=Field([g,pF]) then
       a := 1;
       ex := 0;
-      for i in [0..n-1] do
+      for i in [0..c1-1] do
         if a = h then
           break;
         else
@@ -2436,12 +2432,11 @@ for x in [1..k] do
           a:=a*g;
         fi;
       od;
-      A1 := [1,F,c,[A[4][x][1],acon[x] mod c,ex]];
+      A1 := [1,F,c1,[A[4][x][1],acon[x] mod c1,ex]];
       split := SchurIndex(A1)=1;  
     fi;
     if split then
-      c := Lcm(2,Conductor(F2));
-      g:=E(c);
+      g:=E(c2);
       act := [];
       l := Length(y);
       pos := 1;
@@ -2450,30 +2445,30 @@ for x in [1..k] do
       fi;
       for i in y do
         a:=1;
-        h:=E(con)^A[4][i][3];
-        for ex in [0..c] do
+        h:=E(m)^A[4][i][3];
+        for ex in [0..c2] do
           if a = h then
             break;
           fi;
           a:=a*g;
         od;
-        if ex=c then 
+        if ex=c2 then 
           Print("\n The algebra is not a genuine cyclotomic algebra \n");
           return fail;
         fi;          
-        Add(act,[A[4][i][1], acon[i] mod c, ex]); 
+        Add(act,[A[4][i][1], acon[i] mod c2, ex]); 
         if pos < l then
           coc2 := [];
           for j in [pos+1..l] do
             a:=1;
-            h:=E(con)^A[5][i][y[j]-i];
-            for ex in [0..c] do
+            h:=E(m)^A[5][i][y[j]-i];
+            for ex in [0..c2] do
               if a = h then
                 break;
               fi;
               a:=a*g;
             od;
-            if ex=c then 
+            if ex=c2 then 
              Print("\n The algebra is not a genuine cyclotomic algebra \n");
               return fail;
             fi;          
@@ -2484,13 +2479,16 @@ for x in [1..k] do
         pos := pos+1;
       od;
       if l=1 then 
-        return [A[1]*A[4][x][1],F,c,act[1]];
+        return [A[1]*A[4][x][1],F,c2,act[1]];
       else 
-        return [A[1]*A[4][x][1],F,c,act,coc1];
+        return [A[1]*A[4][x][1],F,c2,act,coc1];
       fi;
     fi;
   fi;
 od;
+
+## AT THIS POINT NO FACTORIZATION A=A1\otimes A2 WITH A1 AND SPLIT AND A2 CYCLOTOMIC HAS BEEN DISCOVERED
+## NOW WE SEARCH FOR A FACTORIZATION WITH BOTH A1 AND A2 CYCLOTOMIC BUT NOT CYCLIC. 
 
 v := [1..k];
 d1 := List(v,i->Filtered(v,j->i=j or e[i,j]<>0));
@@ -2524,12 +2522,13 @@ SortBy(gcls,Size);
 for x in gcls do
   y := Difference(v,x);
   F1:=NF(con,List(y,j->acon[j]));
+  c1 := IsCyclotomicExtension(F1,F);
   F2:=NF(con,List(x,j->acon[j]));
-  if IsCyclotomicExtension(F1,F) and IsCyclotomicExtension(F2,F) then    
+  c2 := IsCyclotomicExtension(F2,F);
+  if c1<>0 and c2<>0 then    
 
 # Construction of the first factor
-    c := Lcm(2,Conductor(F1));
-    g:=E(c);
+    g:=E(c1);
     act := [];
     l := Length(x);
     pos := 1;
@@ -2537,10 +2536,10 @@ for x in gcls do
       coc1 := [];
     fi;
     for i in x do
-      h:=E(con)^A[4][i][3];
+      h:=E(m)^A[4][i][3];
       a := 1;
       ex := 0;
-      for j in [0..c-1] do
+      for j in [0..c1-1] do
         if a = h then
           break;
         else
@@ -2548,23 +2547,23 @@ for x in gcls do
           a:=a*g;
         fi;
       od;
-      if ex=c then 
+      if ex=c1 then 
         Print("\n The algebra is not a genuine cyclotomic algebra \n");
         return fail;
       fi;
-      Add(act,[A[4][i][1],acon[i] mod c,ex]);                  
+      Add(act,[A[4][i][1],acon[i] mod c1,ex]);                  
       if pos < l then
         coc2 := [];
         for j in [pos+1..l] do
           a:=1;
           h:=E(con)^A[5][i][x[j]-i];
-          for ex in [0..c] do
+          for ex in [0..c1] do
             if a = h then
               break;
             fi;
             a:=a*g;
           od;
-          if ex=c then 
+          if ex=c1 then 
             Print("\n The algebra is not a genuine cyclotomic algebra \n");
             return fail;
           fi;          
@@ -2575,14 +2574,13 @@ for x in gcls do
       pos := pos+1;
     od;
     if l=1 then 
-      A1 := [A[1],F,c,act[1]];
+      A1 := [A[1],F,c1,act[1]];
     else 
-      A1 := [A[1],F,c,act,coc1];
+      A1 := [A[1],F,c1,act,coc1];
     fi;
 
 # Construction of the second factor
-    c := Lcm(2,Conductor(F2));
-    g:=E(c);
+    g:=E(c2);
     act := [];
     l := Length(y);
     pos := 1;
@@ -2593,7 +2591,7 @@ for x in gcls do
       h:=E(con)^A[4][i][3];
       a := 1;
       ex := 0;
-      for j in [0..c-1] do
+      for j in [0..c2-1] do
         if a = h then
           break;
         else
@@ -2601,24 +2599,24 @@ for x in gcls do
           a:=a*g;
         fi;
       od;
-      if ex=c then 
+      if ex=c2 then 
         Print("\n The algebra is not a genuine cyclotomic algebra \n");
         return fail;
       fi;
-      Add(act,[A[4][i][1], acon[i] mod c, ex]);
+      Add(act,[A[4][i][1], acon[i] mod c2, ex]);
       
       if pos < l then
         coc2 := [];
         for j in [pos+1..l] do
           a:=1;
           h:=E(con)^A[5][i][y[j]-i];
-          for ex in [0..c] do
+          for ex in [0..c2] do
             if a = h then
               break;
             fi;
             a:=a*g;
           od;
-          if ex=c then 
+          if ex=c2 then 
             Print("\n The algebra is not a genuine cyclotomic algebra \n");
             return fail;
           fi;          
@@ -2630,9 +2628,9 @@ for x in gcls do
     od;
     
     if l=1 then 
-      A2 := [A[1],F,c,act[1]];
+      A2 := [A[1],F,c2,act[1]];
     else 
-      A2 := [A[1],F,c,act,coc1];
+      A2 := [A[1],F,c2,act,coc1];
     fi;
 #    Print("\n", [A1,A2]);
     s1 := SchurIndex(A1);

--- a/lib/div-alg.gi
+++ b/lib/div-alg.gi
@@ -2337,7 +2337,6 @@ for i in [1..k] do
 od;
 
 return [n,F,m,hrs,c];
-
 end);
 
 
@@ -2462,7 +2461,7 @@ for x in [1..k] do
           Print("\n The algebra is not a genuine cyclotomic algebra \n");
           return fail;
         fi;          
-        Add(act,[A[4][i][1] , acon[i] mod c , ex]); 
+        Add(act,[A[4][i][1], acon[i] mod c, ex]); 
         if pos < l then
           coc2 := [];
           for j in [pos+1..l] do
@@ -2606,7 +2605,7 @@ for x in gcls do
         Print("\n The algebra is not a genuine cyclotomic algebra \n");
         return fail;
       fi;
-      Add(act,[A[4][i][1] , acon[i] mod c , ex]);
+      Add(act,[A[4][i][1], acon[i] mod c, ex]);
       
       if pos < l then
         coc2 := [];
@@ -2845,5 +2844,4 @@ for x in gcls do
 od;
 
 return fail;
-
 end;

--- a/lib/div-alg.gi
+++ b/lib/div-alg.gi
@@ -2340,6 +2340,15 @@ return [n,F,m,hrs,c];
 
 end);
 
+
+
+
+
+
+
+
+
+
 ################################################
 # IsCyclotomicExtension checks whether the input are two number fields 
 # and the first is a cyclotomic extension of the second
@@ -2374,32 +2383,38 @@ end);
 InstallGlobalFunction( ReducingCyclotomicAlgebra, function(A)
 #ReducingCyclotomicAlgebra := function(A)
 
-local m,F,pF,K,con,k,e,i,x,y,F1,F2,c,g,h,n,act,coc1,coc2,l,pos,ex,a,j,A1,split,v,w,d1,cls,gcls,lc,A2,s1,s2;
+local m,e,F,pF,K,gal,con,Ucon,k,acA,acon,i,x,y,F1,F2,c,g,h,n,act,coc1,coc2,l,pos,ex,a,j,A1,split,v,w,d1,cls,gcls,lc,A2,s1,s2;
 
 if Length(A) < 5 then
   return fail;
 fi;
 
 m:=A[3];
+e := AntiSymMatUpMat(A[5]);
 F:=A[2];
 pF := PrimitiveElement(F);
 K := Field([pF,E(m)]);
+gal := GaloisGroup(AsField(F,K));
 con := Lcm(2,Conductor(K));
-e := AntiSymMatUpMat(A[5]);
+Ucon := List(Units(ZmodnZ(con)),Int);
 k := Length(A[4]);
+acA := List([1..k],i->Filtered(gal,x->E(m)^x=E(m)^A[4][i][2])[1]);
+acon := List(acA,x->Filtered(Ucon,i->E(con)^i=E(con)^x)[1]);
 
 
 for x in [1..k] do
-  F2:=NF(con,[A[4][x][2]]);
+  F2:=NF(con,[acon[x]]);
   if ForAll([1..k],j->e[x][j]=0) and IsCyclotomicExtension(F2,F) then
     y := Difference([1..k],[x]);
-    F1:=NF(con,List(y,j->A[4][j][2]));
+    F1:=NF(con,List(y,j->acon[j]));
+## A is a tensor product of a cyclic algebra A1=(F1/F,a1) and a cyclotomic algebra A2=F2*H.
+## We check whether a1 is the norm of a root of unity in F, so that A1 is split.
     c := Lcm(2,Conductor(F1));
     g := E(c);
     while not g in F1 do
       g:=g*E(c);
     od;
-    h := E(con)^A[4][x][3];
+    h := E(m)^A[4][x][3];
     n := Order(g);
     split := false;
     a := 1;
@@ -2410,7 +2425,7 @@ for x in [1..k] do
       fi;
       a:=a*g;
     od;
-## If not we check whether it is a cyclotomic and compute the Schur index to check whether it is 1
+## If not we check whether A1 is cyclotomic and compute the Schur index of A1. 
     if not split and IsCyclotomicExtension(F1,F) then
       a := 1;
       ex := 0;
@@ -2422,7 +2437,7 @@ for x in [1..k] do
           a:=a*g;
         fi;
       od;
-      A1 := [1,F,c,[A[4][x][1],A[4][x][2] mod c,ex]];
+      A1 := [1,F,c,[A[4][x][1],acon[x] mod c,ex]];
       split := SchurIndex(A1)=1;  
     fi;
     if split then
@@ -2447,7 +2462,7 @@ for x in [1..k] do
           Print("\n The algebra is not a genuine cyclotomic algebra \n");
           return fail;
         fi;          
-        Add(act,[A[4][i][1],A[4][i][2] mod c,ex]); 
+        Add(act,[A[4][i][1] , acon[i] mod c , ex]); 
         if pos < l then
           coc2 := [];
           for j in [pos+1..l] do
@@ -2509,8 +2524,8 @@ SortBy(gcls,Size);
 
 for x in gcls do
   y := Difference(v,x);
-  F1:=NF(con,List(y,j->A[4][j][2]));
-  F2:=NF(con,List(x,j->A[4][j][2]));
+  F1:=NF(con,List(y,j->acon[j]));
+  F2:=NF(con,List(x,j->acon[j]));
   if IsCyclotomicExtension(F1,F) and IsCyclotomicExtension(F2,F) then    
 
 # Construction of the first factor
@@ -2538,7 +2553,7 @@ for x in gcls do
         Print("\n The algebra is not a genuine cyclotomic algebra \n");
         return fail;
       fi;
-      Add(act,[A[4][i][1],A[4][i][2] mod c,ex]);                  
+      Add(act,[A[4][i][1],acon[i] mod c,ex]);                  
       if pos < l then
         coc2 := [];
         for j in [pos+1..l] do
@@ -2591,7 +2606,7 @@ for x in gcls do
         Print("\n The algebra is not a genuine cyclotomic algebra \n");
         return fail;
       fi;
-      Add(act,[A[4][i][1],A[4][i][2] mod c,ex]);
+      Add(act,[A[4][i][1] , acon[i] mod c , ex]);
       
       if pos < l then
         coc2 := [];
@@ -2625,7 +2640,7 @@ for x in gcls do
     s2 := SchurIndex(A2);
     if s1=1 then
       if s2 =1 then
-        return [A[1],F];
+        return [A[1]*Product(A1[4],x->x[1]),F];
       else
         A2[1] := A2[1]*Product(A1[4],x->x[1]);
         return A2;

--- a/lib/main.gi
+++ b/lib/main.gi
@@ -1290,7 +1290,7 @@ end);
 ## 4th position = Galois group of a crossed product
 ## 5th position = the cocycle
 ##
-## The output is list of 2, 3, 4 or 5 elements:
+## The output is list of 2, 4 or 5 elements:
 ## 1st position = the size of the matrices
 ## 2nd position = the centre of the simple component
 ## 3rd position = integer that is the order of the root of unity
@@ -1322,7 +1322,8 @@ genF,           # E(Cond)
 powgenF,        # Powers of genF
 beta,           # numerical value of cyclic cocycle 
 h,              # Group element
-c;              # Value of cocycle 
+c,              # Value of cocycle 
+A;              # Info of the algebra before using GlobalSplittingOfCyclotomicAlgebra and SchurIndex
 
 if Length(x) = 2 then 
     return x;
@@ -1374,14 +1375,14 @@ else
     od;
          
     if Size(Gen)=1 then
-        return [ x[1],                          # the size of matrices
+        A:= [ x[1],                          # the size of matrices
                  x[2],                          # the centre of the simple component
                  Cond,                          # the order of the root of unity
                  [ o[1], Int(Gen[1]) , beta[1]] #
                ]; 
                    
     else
-        return [ x[1],
+        A:= [ x[1],
                  x[2],
                  Cond,
                  List([1..Length(Gen)], i -> [ o[i], Int(Gen[i]) , beta[i] ] ),
@@ -1392,7 +1393,17 @@ else
                      )
                 ];        
     fi;       
-
+  return GlobalSplittingOfCyclotomicAlgebra(A);
+  if Length(A) = 2 or SchurIndex(A)<>1 then 
+    return A;
+  else
+    if Length(A)=4 then 
+      A[1]:=A[1]*A[4][1];
+    else 
+      A[1]:=A[1]*Product(List(A[4],x->x[1]));
+    fi;
+    return [A[1],A[2]];
+  fi;
 fi;
 
 end);

--- a/tst/div-alg.tst
+++ b/tst/div-alg.tst
@@ -36,6 +36,8 @@ gap> B:=ReducingCyclotomicAlgebra(A);
 [ 4, Rationals, 30, [ [ 2, 11, 0 ], [ 4, 7, 0 ] ], [ [ 15 ] ] ]
 gap> LocalIndicesOfCyclotomicAlgebra(B);
 [ [ 3, 2 ], [ 5, 2 ] ]
+gap> SchurIndex(A);
+2
 
 #
 gap> STOP_TEST( "div-alg.tst", 1 );


### PR DESCRIPTION
The definition of the fields F1 and F2 have been modified.
F1=K^G1 and F2=K^G2 where K=F(E(m)) with F=A[2] and  m=A[3]. The error consists in assuming that m coincides with the conductor of K.
G1 and G2 are expressed in terms of the information in A[4] which in turn is expresed in terms of m.
To define F1 and F2 properly is necessarily to express the information of A[4] in terms of the conductor of K.
Another bug fixed in the return for the case where s1=s2=1, i.e. when the algebra is split.