### PR TITLE
Test for some special cases in DecomposeCyclotomicAlgebra

### DIFF
--- a/tst/div-alg.tst
+++ b/tst/div-alg.tst
@@ -39,5 +39,15 @@ gap> LocalIndicesOfCyclotomicAlgebra(B);
 gap> SchurIndex(A);
 2
 
+# Some special cases in DecomposeCyclotomicAlgebra (PR #81)
+gap> QG:=GroupRing(Rationals,SmallGroup(240,96));;
+gap> W:=WedderburnDecompositionInfo(QG);;
+gap> Length(W);
+18
+gap> A:=W[Length(W)];
+[ 1, Rationals, 30, [ [ 2, 11, 0 ], [ 4, 7, 0 ] ], [ [ 15 ] ] ]
+gap> DecomposeCyclotomicAlgebra(A);
+[ [ Rationals, CF(3), [ 1 ] ], [ Rationals, CF(5), [ 0 ] ] ]
+
 #
 gap> STOP_TEST( "div-alg.tst", 1 );


### PR DESCRIPTION
Attempts to find examples with increased coverage. Trying suggestions by @drallenherman from the discussion in #76:
```
# Split simple components of dimension 16^2
gap> QG:=GroupRing(Rationals,SmallGroup(1920,136971));;
gap> W:=WedderburnDecompositionInfo(QG);;
gap> Length(W);
93
gap> A:=W[Length(W)];
[ 16, GaussianRationals ]
gap> LocalIndicesOfCyclotomicAlgebra(A);
[  ]
gap> QG:=GroupRing(Rationals,SmallGroup(1920,204811));;
gap> W:=WedderburnDecompositionInfo(QG);;
gap> Length(W);
105
gap> A:=W[Length(W)];
[ 16, NF(20,[ 1, 3, 7, 9 ]) ]
gap> LocalIndicesOfCyclotomicAlgebra(A);
[  ]
```
