### PR TITLE
Use elif in LocalIndicesOfRationalSymbolAlgebra

### DIFF
--- a/lib/div-alg.gi
+++ b/lib/div-alg.gi
@@ -1596,36 +1596,53 @@ end);
 InstallGlobalFunction( LocalIndicesOfRationalSymbolAlgebra, function(a,b)
 local p,q,L,t;
 
-p:=a;
-q:=b;
 L:=[];
-if p < q then
+
+if a < b then
   p:=b;
   q:=a;
+else
+  p:=a;
+  q:=b;
 fi;
 
 if not(ForAll([p,q],t -> t=-1 or (IsPosInt(t) and IsPrimeInt(t)))) then
-return fail;
+  return fail;
 fi;
 
-if p=-1 then L:=[[infinity,2],[2,2]]; fi;
-if p=2 then L:=[]; fi;
-if p>2 then
+if p=-1 then 
+  L:=[[infinity,2],[2,2]];
+elif p=2 then 
+  L:=[];
+elif p>2 then
   if q=-1 then
-    if Legendre(q,p)=-1 then L:=[[2,2],[p,2]]; else L:=[]; fi;
-  fi;
-  if q=2 then
-    if Legendre(2,p)=-1 then L:=[[2,2],[p,2]]; else L:=[]; fi;
-  fi;
-  if p>q and q>2 then
     if Legendre(q,p)=-1 then
-       if Legendre(p,q)=-1 then L:=[[q,2],[p,2]]; else L:=[[2,2],[p,2]]; fi;
+      L:=[[2,2],[p,2]];
     else
-       if Legendre(p,q)=-1 then L:=[[2,2],[q,2]]; fi;
+      L:=[];
     fi;
-  fi;
-  if p=q then
-    if Legendre(-1,p)=-1 then L:=[[2,2],[p,2]]; fi;
+  elif q=2 then
+    if Legendre(2,p)=-1 then
+      L:=[[2,2],[p,2]];
+    else
+      L:=[];
+    fi;
+  elif p>q and q>2 then
+    if Legendre(q,p)=-1 then
+       if Legendre(p,q)=-1 then
+         L:=[[q,2],[p,2]];
+       else
+         L:=[[2,2],[p,2]];
+       fi;
+    else
+       if Legendre(p,q)=-1 then
+         L:=[[2,2],[q,2]];
+       fi;
+    fi;
+  elif p=q then
+    if Legendre(-1,p)=-1 then
+      L:=[[2,2],[p,2]];
+    fi;
   fi;
 fi;
 return L;

--- a/tst/div-alg.tst
+++ b/tst/div-alg.tst
@@ -71,5 +71,21 @@ gap> A:=W[Length(W)];
 gap> DecomposeCyclotomicAlgebra(A);
 [ [ Rationals, CF(3), [ 1 ] ], [ Rationals, CF(5), [ 9 ] ] ]
 
+# LocalIndicesOfRationalSymbolAlgebra (PR #83)
+gap> List([-2..3],a->LocalIndicesOfRationalSymbolAlgebra(a,-2));
+[ fail, fail, fail, fail, fail, fail ]
+gap> List([-2..3],a->LocalIndicesOfRationalSymbolAlgebra(a,-1));
+[ fail, [ [ infinity, 2 ], [ 2, 2 ] ], fail, fail, [  ], [ [ 2, 2 ], [ 3, 2 ] ] ]
+gap> List([-2..3],a->LocalIndicesOfRationalSymbolAlgebra(a,2));
+[ fail, [  ], fail, fail, [  ], [ [ 2, 2 ], [ 3, 2 ] ] ]
+gap> List([-2..3],a->LocalIndicesOfRationalSymbolAlgebra(a,3));
+[ fail, [ [ 2, 2 ], [ 3, 2 ] ], fail, fail, [ [ 2, 2 ], [ 3, 2 ] ], [ [ 2, 2 ], [ 3, 2 ] ] ]
+gap> List([-2..3],a->LocalIndicesOfRationalSymbolAlgebra(a,5));
+[ fail, [  ], fail, fail, [ [ 2, 2 ], [ 5, 2 ] ], [ [ 3, 2 ], [ 5, 2 ] ] ]
+gap> List([-2..3],a->LocalIndicesOfRationalSymbolAlgebra(a,7));
+[ fail, [ [ 2, 2 ], [ 7, 2 ] ], fail, fail, [  ], [ [ 2, 2 ], [ 7, 2 ] ] ]
+gap> List([-2..3],a->LocalIndicesOfRationalSymbolAlgebra(a,11));
+[ fail, [ [ 2, 2 ], [ 11, 2 ] ], fail, fail, [ [ 2, 2 ], [ 11, 2 ] ], [ [ 2, 2 ], [ 3, 2 ] ] ]
+
 #
 gap> STOP_TEST( "div-alg.tst", 1 );


### PR DESCRIPTION
This is a follow-up to #82 which optimises the code by using `elif` instead of multiple `if`, avoiding redundant checks.