### PR TITLE
Accommodate correctly pluralized ViewStrings in GAP

### DIFF
--- a/doc/crossed.xml
+++ b/doc/crossed.xml
@@ -92,8 +92,8 @@ to describe the action.
 <![CDATA[
 gap> R := GaussianRationals;
 GaussianRationals
-gap> G := Units( ZmodnZ(4) );
-<group of size 2 with 1 generators>
+gap> G := Units( ZmodnZ(4) );; Size( G );
+2
 gap> act := function(RG,g)
 > return ANFAutomorphism( LeftActingDomain(RG), Int(g) );
 > end;
@@ -159,8 +159,7 @@ using the rationals as coefficient ring and the Klein group as the underlying gr
 
 <Example>
 <![CDATA[
-gap> C2 := CyclicGroup(2);
-<pc group of size 2 with 1 generators>
+gap> C2 := CyclicGroup(2);;
 gap> G := DirectProduct(C2,C2);
 <pc group of size 4 with 2 generators>
 gap> act := function(RG,a)

--- a/tst/wedderga05.tst
+++ b/tst/wedderga05.tst
@@ -12,8 +12,8 @@ gap> START_TEST( "wedderga05.tst");
 
 gap> R := GaussianRationals;
 GaussianRationals
-gap> G := Units( ZmodnZ(4) );
-<group of size 2 with 1 generators>
+gap> G := Units( ZmodnZ(4) );; Size( G );
+2
 gap> act := function(RG,g)
 > return ANFAutomorphism( LeftActingDomain(RG), Int(g) );
 > end;
@@ -62,10 +62,9 @@ gap> j^2;
 gap> i*j+j*i;                       
 <zero> of ...
 
-# doc/crossed.xml:160-192
+# doc/crossed.xml:160-191
 
-gap> C2 := CyclicGroup(2);
-<pc group of size 2 with 1 generators>
+gap> C2 := CyclicGroup(2);;
 gap> G := DirectProduct(C2,C2);
 <pc group of size 4 with 2 generators>
 gap> act := function(RG,a)
@@ -94,7 +93,7 @@ function( RG, g, h ) ... end
 gap> HQ := CrossedProduct( Rationals, G, act, twist );
 <crossed product over Rationals of a group of size 4>
 
-# doc/crossed.xml:196-211
+# doc/crossed.xml:195-210
 
 gap> HZ := CrossedProduct( Integers, G, act, twist );
 <crossed product over Integers of a group of size 4>
@@ -109,7 +108,7 @@ gap> j^2;
 gap> i*j+j*i;                                      
 <zero> of ...
 
-# doc/crossed.xml:224-240
+# doc/crossed.xml:223-239
 
 gap> LeftActingDomain(HZ);
 Integers
@@ -125,7 +124,7 @@ function( RG, g, h ) ... end
 gap> List( G, x -> List( G , y -> tw( HZ, x, y ) ) );
 [ [ 1, 1, 1, 1 ], [ 1, -1, -1, 1 ], [ 1, 1, -1, -1 ], [ 1, -1, 1, -1 ] ]  
 
-# doc/crossed.xml:246-284
+# doc/crossed.xml:245-283
 
 gap> G := SmallGroup(32,50);
 <pc group of size 32 with 5 generators>
@@ -163,7 +162,7 @@ gap> List( H , x -> ac( B, x ) );
 gap> List( H , x -> List( H , y -> tw( B, x, y ) ) );
 [ [ 1, 1 ], [ 1, -1 ] ]
 
-# doc/crossed.xml:287-342
+# doc/crossed.xml:286-341
 
 gap> QG:=GroupRing( Rationals, SmallGroup(24,3) );;
 gap> WedderburnDecomposition(QG);
@@ -218,7 +217,7 @@ gap> Characteristic(R);
 gap> CenterOfCrossedProduct(R);
 Rationals
 
-# doc/crossed.xml:348-402
+# doc/crossed.xml:347-401
 
 gap> Quat := function(R,a,b)
 > local G,act,twist;
@@ -272,7 +271,7 @@ function( RG, g, h ) ... end
 gap> List( G, x -> List( G, y -> tw( HQ, x, y ) ) );
 [ [ 1, 1, 1, 1 ], [ 1, 3, -1, -3 ], [ 1, 1, 2, 2 ], [ 1, 3, -3, -6 ] ]
 
-# doc/crossed.xml:448-480
+# doc/crossed.xml:447-479
 
 gap> QG := GroupRing( Rationals, SmallGroup(24,3) );
 <algebra-with-one over Rationals, with 4 generators>


### PR DESCRIPTION
In a future version of GAP, some nouns will be correctly pluralised to match their number.  For example, the `ViewString` for `CyclicGroup(3);` will change from `<pc group of size 3 with 1 generators>` to `<pc group of size 3 with 1 generator>`.

The changes in this PR maintain the backwards and forwards compatibility of this package with GAP.

See gap-system/gap#3992 and gap-system/gap#4050 for more context.