### PR TITLE
Add testing with stable-4.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,7 @@ jobs:
       matrix:
         gap-branch:
           - master
+          - stable-4.12
           - stable-4.11
           - stable-4.10
           - stable-4.9

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
             ABI: 32
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gap-actions/setup-gap@v2
         with:
           GAPBRANCH: ${{ matrix.gap-branch }}

--- a/doc/div-alg.xml
+++ b/doc/div-alg.xml
@@ -149,13 +149,18 @@ gap> SchurIndexByCharacter(GaussianRationals,G,Irr(G)[i]);
 2
 gap> SchurIndexByCharacter(CF(3),G,i);
 1
+]]>
+</Example>
+
+<Log>
+<![CDATA[
 gap> G:=AtlasGroup("J2");
 <permutation group of size 604800 with 2 generators>
 gap> Irr(G)[20];;
 gap> SchurIndexByCharacter(Rationals,G,Irr(G)[20]);
 1
 ]]>
-</Example>
+</Log>
 
    </Description>
 </ManSection>

--- a/tst/wedderga07.tst
+++ b/tst/wedderga07.tst
@@ -51,7 +51,7 @@ gap> CyclotomicAlgebraWithDivAlgPart(W[10]);
 [ 3, rec( Center := NF(8,[ 1, 7 ]), DivAlg := true,
       LocalIndices := [ [ infinity, 2 ] ], SchurIndex := 2 ) ]
 
-# doc/div-alg.xml:134-158
+# doc/div-alg.xml:134-153
 
 gap> G:=SmallGroup(63,1);
 <pc group of size 63 with 3 generators>
@@ -69,13 +69,8 @@ gap> SchurIndexByCharacter(GaussianRationals,G,Irr(G)[i]);
 2
 gap> SchurIndexByCharacter(CF(3),G,i);
 1
-gap> G:=AtlasGroup("J2");
-<permutation group of size 604800 with 2 generators>
-gap> Irr(G)[20];;
-gap> SchurIndexByCharacter(Rationals,G,Irr(G)[20]);
-1
 
-# doc/div-alg.xml:189-214
+# doc/div-alg.xml:194-219
 
 gap> G:=SmallGroup(63,1);
 <pc group of size 63 with 3 generators>
@@ -100,14 +95,14 @@ gap> SimpleComponentByCharacterAsSCAlgebra(Rationals,G,15);
 <algebra of dimension 9 over NF(21,[ 1, 4, 16 ])>
 
 
-# doc/div-alg.xml:238-245
+# doc/div-alg.xml:243-250
 
 gap> PPartOfN(2275,5);
 25
 gap> PDashPartOfN(2275,5);
 91
 
-# doc/div-alg.xml:262-272
+# doc/div-alg.xml:267-277
 
 gap> PSplitSubextension(Rationals,60,5);
 GaussianRationals
@@ -117,7 +112,7 @@ gap> PSplitSubextension(NF(40,[1,9,11,19]),20,2);
 NF(40,[ 1, 9, 11, 19])
 
 
-# doc/div-alg.xml:295-315
+# doc/div-alg.xml:300-320
 
 gap> F:=CF(12);
 CF(12)
@@ -137,7 +132,7 @@ gap> SplittingDegreeAtP(F,120,5); SplittingDegreeAtP(K,120,5); last2/last;
 1
 2
 
-# doc/div-alg.xml:375-384
+# doc/div-alg.xml:380-389
 
 gap> A := [ 1, Rationals, 20, [ [ 2, 11, 0 ], [ 4, 3, 0 ] ], [ [ 0 ] ] ];;
 gap> GlobalSplittingOfCyclotomicAlgebra(A);
@@ -146,7 +141,7 @@ gap> A := [ 1, Rationals, 20, [ [ 2, 11, 0 ], [ 4, 3, 10 ] ], [ [ 0 ] ] ];;
 gap> GlobalSplittingOfCyclotomicAlgebra(A);
 [ 2, Rationals, 10, [ 4, 3, 5 ] ]
 
-# doc/div-alg.xml:433-443
+# doc/div-alg.xml:438-448
 
 gap> G:=PSU(3,3);
 <permutation group of size 6048 with 2 generators>
@@ -156,7 +151,7 @@ gap> sc{[1..3]}; # the 4th entry is [ 2, 5, 3 ] or [ 2, 5, 9 ]
 gap> SchurIndex(sc);
 1
 
-# doc/div-alg.xml:465-478
+# doc/div-alg.xml:470-483
 
 gap> G:=SmallGroup(63,1);
 <pc group of size 63 with 3 generators>
@@ -169,7 +164,7 @@ gap> GaloisRepsOfCharacters(NF(7,[1,2,4]),G);
 gap> GaloisRepsOfCharacters(CF(63),G);
 [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 ]
 
-# doc/div-alg.xml:506-519
+# doc/div-alg.xml:511-524
 
 gap> G:=GL(3,3);
 GL(3,3)
@@ -182,14 +177,14 @@ gap> WedderburnDecompositionByCharacterDescent(Rationals,G);
 [ 26, NF(8,[ 1, 3 ]) ], [ 26, NF(8,[ 1, 3 ]) ], [ 27, Rationals ],
 [ 27, Rationals ], [ 39, Rationals ], [ 39, Rationals ] ]
 
-# doc/div-alg.xml:546-553
+# doc/div-alg.xml:551-558
 
 gap> A:=[1,Rationals,6,[2,5,3]];
 [ 1, Rationals, 6, [ 2, 5, 3 ] ]
 gap> LocalIndicesOfCyclicCyclotomicAlgebra(A);
 [ [ 3, 2 ], [ infinity, 2 ] ]
 
-# doc/div-alg.xml:591-606
+# doc/div-alg.xml:596-611
 
 gap> A:=[1,CF(4),20,[4,13,15]];
 [ 1, GaussianRationals, 20, [ 4, 13, 15 ] ]
@@ -204,7 +199,7 @@ gap> A:=[1,CF(7),28,[2,15,14]];
 gap> LocalIndexAtTwo(A);
 2
 
-# doc/div-alg.xml:656-669
+# doc/div-alg.xml:661-674
 
 gap> G:=SmallGroup(480,600);
 <pc group of size 480 with 7 generators>
@@ -217,7 +212,7 @@ gap> W[27];
 gap> LocalIndicesOfCyclotomicAlgebra(W[27]);
 [ [ infinity, 2 ] ]
 
-# doc/div-alg.xml:671-683
+# doc/div-alg.xml:676-688
 
 gap> G:=SmallGroup(160,82);
 <pc group of size 160 with 6 generators>
@@ -229,14 +224,14 @@ gap> W[14];
 gap> LocalIndicesOfCyclotomicAlgebra(W[14]);
 [ [ 2, 2 ], [ 5, 2 ] ]
 
-# doc/div-alg.xml:697-704
+# doc/div-alg.xml:702-709
 
 gap> A:=[3,Rationals,12,[[2,5,3],[2,7,0]],[[3]]];
 [ 3, Rationals, 12, [ [ 2, 5, 3 ], [ 2, 7, 0 ] ], [ [ 3 ] ] ]
 gap> RootOfDimensionOfCyclotomicAlgebra(A);
 12
 
-# doc/div-alg.xml:734-753
+# doc/div-alg.xml:739-758
 
 gap> G:=SmallGroup(48,15);
 <pc group of size 48 with 5 generators>
@@ -255,7 +250,7 @@ gap> SimpleComponentOfGroupRingByCharacter(Rationals,G,n)
 > ;#Note:this cyclotomic algebra is isomorphic to the other by a change of basis.
 [ 1, Rationals, 12, [ [ 2, 5, 3 ], [ 2, 7, 0 ] ], [ [ 3 ] ] ]
 
-# doc/div-alg.xml:768-779
+# doc/div-alg.xml:773-784
 
 gap> G:=SmallGroup(48,16);
 <pc group of size 48 with 5 generators>
@@ -266,7 +261,7 @@ gap> LocalIndexAtInftyByCharacter(CF(3),G,Irr(G)[i]);
 1
 
 
-# doc/div-alg.xml:812-828
+# doc/div-alg.xml:817-833
 
 gap> G:=SmallGroup(72,21);
 <pc group of size 72 with 5 generators>
@@ -282,7 +277,7 @@ false
 gap> DefectOfCharacterAtP(G,Irr(G)[i],3);
 2
 
-# doc/div-alg.xml:870-883
+# doc/div-alg.xml:875-888
 
 gap> G:=SmallGroup(80,28);
 <pc group of size 80 with 5 generators>
@@ -295,7 +290,7 @@ gap> LocalIndexAtPByBrauerCharacter(Rationals,G,i,5);
 gap> FinFieldExt(Rationals,G,5,i,9);
 2
 
-# doc/div-alg.xml:885-895
+# doc/div-alg.xml:890-900
 
 gap> G:=SmallGroup(72,20);
 <pc group of size 72 with 5 generators>
@@ -305,7 +300,7 @@ gap> LocalIndexAtPByBrauerCharacter(Rationals,G,Irr(G)[i],3);
 gap> LocalIndexAtPByBrauerCharacter(Rationals,G,i,2);
 1
 
-# doc/div-alg.xml:939-951
+# doc/div-alg.xml:944-956
 
 gap> G:=SmallGroup(48,15);
 <pc group of size 48 with 5 generators>
@@ -317,7 +312,7 @@ gap> LocalIndexAtTwoByCharacter(Rationals,G,Irr(G)[i]);
 gap> LocalIndexAtTwoByCharacter(CF(3),G,Irr(G)[i]);
 1
 
-# doc/div-alg.xml:1006-1025
+# doc/div-alg.xml:1011-1030
 
 gap> LocalIndicesOfRationalSymbolAlgebra(-1,-1);
 [ [ infinity, 2 ], [ 2, 2 ] ]
@@ -336,7 +331,7 @@ gap> A:=QuaternionAlgebra(CF(5),3,-2);
 gap> LocalIndicesOfRationalQuaternionAlgebra(A);
 fail
 
-# doc/div-alg.xml:1051-1066
+# doc/div-alg.xml:1056-1071
 
 gap> A:=QuaternionAlgebra(Rationals,-30,-15);
 <algebra-with-one of dimension 4 over Rationals>
@@ -351,7 +346,7 @@ false
 gap> LocalIndicesOfRationalQuaternionAlgebra(A);
 [  ]
 
-# doc/div-alg.xml:1117-1130
+# doc/div-alg.xml:1122-1135
 
 gap> G:=SmallGroup(96,35);
 <pc group of size 96 with 6 generators>
@@ -364,7 +359,7 @@ gap> DecomposeCyclotomicAlgebra(A);
 [ [ NF(8,[ 1, 7 ]), CF(8), [ -1 ] ],
   [ NF(8,[ 1, 7 ]), NF(24,[ 1, 7 ]), [ E(8)+2*E(8)^2+E(8)^3 ] ] ]
 
-# doc/div-alg.xml:1154-1172
+# doc/div-alg.xml:1159-1177
 
 gap> A:=[NF(24,[1,11]),CF(24),[-1]];
 [ NF(24,[ 1, 11 ]), CF(24), [ -1 ] ]
@@ -382,7 +377,7 @@ e
 gap> b[2]*b[3]+b[3]*b[2];
 0*e
 
-# doc/div-alg.xml:1199-1219
+# doc/div-alg.xml:1204-1224
 
 gap> A:=QuaternionAlgebra(CF(5),-3,-1);
 <algebra-with-one of dimension 4 over CF(5)>


### PR DESCRIPTION
This also removed one of the examples form testing (but I still keep it as log, we can return it when minimal testing will be under GAP 4.12.

As @fingolfin explained, old AtlasRep can't download things anymore because of http -> https redirects with which the old download method (using IO package) can't handle.
