### PR TITLE
Hide irrelevant test output to make it resilient against changes

### DIFF
--- a/doc/div-alg.xml
+++ b/doc/div-alg.xml
@@ -745,8 +745,7 @@ gap> R:=GroupRing(Rationals,G);
 gap> W:=WedderburnDecompositionInfo(R);;
 gap> A:=W[10];
 [ 1, Rationals, 12, [ [ 2, 5, 3 ], [ 2, 7, 0 ] ], [ [ 3 ] ] ]
-gap> g:=DefiningGroupOfCyclotomicAlgebra(A);
-Group([ f3*f4*f5, f1, f2 ])
+gap> g:=DefiningGroupOfCyclotomicAlgebra(A);;
 gap> IdSmallGroup(g);
 [ 48, 15 ]
 gap> n:=DefiningCharacterOfCyclotomicAlgebra(A);

--- a/tst/wedderga07.tst
+++ b/tst/wedderga07.tst
@@ -240,8 +240,7 @@ gap> R:=GroupRing(Rationals,G);
 gap> W:=WedderburnDecompositionInfo(R);;
 gap> A:=W[10];
 [ 1, Rationals, 12, [ [ 2, 5, 3 ], [ 2, 7, 0 ] ], [ [ 3 ] ] ]
-gap> g:=DefiningGroupOfCyclotomicAlgebra(A);
-Group([ f3*f4*f5, f1, f2 ])
+gap> g:=DefiningGroupOfCyclotomicAlgebra(A);;
 gap> IdSmallGroup(g);
 [ 48, 15 ]
 gap> n:=DefiningCharacterOfCyclotomicAlgebra(A);


### PR DESCRIPTION
The output is equal in GAP 4.13.0 but its printing changes from

    Group([ f3*f4*f5, f1, f2 ])

to

    <pc group of size 48 with 5 generators>

Since the very next thing that happens is that `IdGroup` is called
on this group, it seems fair to just suppress the output.
