### PR TITLE
New version of IsDyadicSchurGroup

### DIFF
--- a/doc/manualbib.xml
+++ b/doc/manualbib.xml
@@ -205,7 +205,11 @@
     <name><first>Inneke</first><last>Van Gelder</last></name>
   </author>  
   <title>Construction of minimal non-abelian left group codes</title>
-  <year>preprint</year>
+  <journal>Des. Codes Cryptography</journal>
+  <year>2015</year>
+  <volume>75</volume>
+  <number>3</number>
+  <pages>359&ndash;373</pages>
 </article></entry>
 
 <entry id="P"><book>

--- a/lib/div-alg.gi
+++ b/lib/div-alg.gi
@@ -740,38 +740,78 @@ end);
 
 ##########################################
 InstallGlobalFunction( IsDyadicSchurGroup, function(G)
-local d,j,P,P1,V0,c,g,g1,z,V1,v1,V2,q,s,n1,r,i,y,p1,x,U,V,P2,L;
+local t,d,P,l,P1,l1,p1,i,Y,q,U,V,V1,L,P2,l2;
 
 d:=false;
-j:=0;
 P:=SylowSubgroup(G,2);
-q:=Size(G)/Size(P);
-if IsPrimeInt(q) then
-U:=SylowSubgroup(G,q);
-V:=Centralizer(P,U);
 
-# First look for G of type (Q_8,q)
-if IdSmallGroup(V)=[8,4] then
- V1:=Centralizer(P,V);
- L:=UnionSet(Elements(V),Elements(V1));
- P2:=GroupByGenerators(L);
- if P=P2 then
-  d:=true;
-  j:=1;
- fi;
-else
-# Checks if P is of type (QD,q)
-P1:=DerivedSubgroup(P);
- s:=LogInt(Size(P)/Size(P1),2)-1;
- if s=LogInt(PPartOfN(OrderMod(2,q),2),2) then
- if not(IsAbelian(V)) then
- if Size(P)/Size(V)=2^s then
- d:=true;
- fi;
- fi;
- fi;
+#### Check that G = Q8 ######
+if G=P then
+  if IdSmallGroup(G)=[8,4] then
+    d:=true;
+  fi;
 fi;
 
+#### Check G is semidirect product of C_q by P, q odd prime ####
+if d=false then
+  q:=Size(G)/Size(P);
+  if IsPrimeInt(q) then
+    U:=SylowSubgroup(G,q);
+    V:=Centralizer(P,U);
+    if not(V=P) then
+
+### Check if G is of type (Q8,q) ####
+      if IdSmallGroup(V)=[8,4] then
+        V1:=Centralizer(P,V);
+        L:=UnionSet(Elements(V),Elements(V1));
+        P2:=GroupByGenerators(L);
+        if P=P2 then
+          if PPartOfN(OrderMod(2,q),2)=Size(P/V) then
+            d:=true;
+          fi;
+        fi;
+      fi;
+
+#### Check that P is a dyadic 2-group #####
+      if d=false then
+        t:=false;
+        l:=Size(P);
+        P1:=DerivedSubgroup(P);
+        l1:=Size(P1);
+        if l>l1 and IsInt(l1/4) and IsCyclic(P1) then
+          p1:=GeneratorsOfGroup(P1);
+          for i in [1..Length(p1)] do
+          if Order(p1[i])=l1 then
+            break;
+          fi;
+          od;
+          Y:=Centralizer(P,p1[i]^(l1/4));
+          if IsCyclic(Y/P1) then
+            t:=true;
+          fi;
+          if IdSmallGroup(V)=[8,4] then
+            if not(PPartOfN(OrderMod(2,q),2)>Size(P/V)) then
+              t:=false;
+            fi;
+          fi;
+
+#### Check if G is of type (QD,q) ###
+          if t=true then
+            if not(IsAbelian(V)) then
+              l2:=Size(V);
+              if l2/l1=2 then
+                if not(PPartOfN(OrderMod(2,q),2)<Size(P/V)) then
+                  d:=true;
+                fi;
+              fi;
+            fi;
+          fi;
+####
+        fi;
+      fi;
+    fi;
+####
+  fi;
 fi;
 
 return d;

--- a/lib/div-alg.gi
+++ b/lib/div-alg.gi
@@ -760,7 +760,7 @@ if d=false then
     V:=Centralizer(P,U);
     if not(V=P) then
 
-### Check if G is of type (Q8,q) ####
+      ### Check if G is of type (Q8,q) ####
       if IdSmallGroup(V)=[8,4] then
         V1:=Centralizer(P,V);
         L:=UnionSet(Elements(V),Elements(V1));
@@ -772,7 +772,7 @@ if d=false then
         fi;
       fi;
 
-#### Check that P is a dyadic 2-group #####
+      #### Check that P is a dyadic 2-group #####
       if d=false then
         t:=false;
         l:=Size(P);
@@ -781,9 +781,9 @@ if d=false then
         if l>l1 and IsInt(l1/4) and IsCyclic(P1) then
           p1:=GeneratorsOfGroup(P1);
           for i in [1..Length(p1)] do
-          if Order(p1[i])=l1 then
-            break;
-          fi;
+            if Order(p1[i])=l1 then
+              break;
+            fi;
           od;
           Y:=Centralizer(P,p1[i]^(l1/4));
           if IsCyclic(Y/P1) then
@@ -795,7 +795,7 @@ if d=false then
             fi;
           fi;
 
-#### Check if G is of type (QD,q) ###
+          #### Check if G is of type (QD,q) ###
           if t=true then
             if not(IsAbelian(V)) then
               l2:=Size(V);
@@ -806,11 +806,11 @@ if d=false then
               fi;
             fi;
           fi;
-####
+          ####
         fi;
       fi;
     fi;
-####
+    ####
   fi;
 fi;
 
@@ -1145,40 +1145,40 @@ m:=0;
 B:=SimpleComponentOfGroupRingByCharacter(F,G,n);
 
 if Length(B)=2 then
-m2:=1;
+  m2:=1;
 fi;
 if Length(B)=4 then
-m2:=LocalIndexAtTwo(B);
+  m2:=LocalIndexAtTwo(B);
 fi;
 
 if Length(B)=5 then
   K:=PSplitSubextension(F,B[3],2);
   B1:=SimpleComponentOfGroupRingByCharacter(K,G,n);
   if Length(B1)<5 then
-     if Length(B1)=2 then m2:=1; fi;
-     if Length(B1)=4 then m2:=LocalIndexAtTwo(B1); fi;
+    if Length(B1)=2 then m2:=1; fi;
+    if Length(B1)=4 then m2:=LocalIndexAtTwo(B1); fi;
   else
-  g:=DefiningGroupAndCharacterOfCyclotAlg(B1);
-  if g=fail then
-    m2:=1;
-  else
-    m2:=LocalIndexAtPByBrauerCharacter(K,g[1],g[2],2);
-  fi;
-  if not(m2 in Integers) then
-    m:=1;
-    if IsDyadicSchurGroup(g[1]) then
-    m:=2;
-    V:=ValuesOfClassFunction(chi);
-    F0:=FieldByGenerators(V);
-    F1:=B1[2];
-      if not(F0=F1) then
-        if E(4) in F1 then
-          m:=1;
-        else
-          n0:=Conductor(F0);
-          n02:=PPartOfN(n0,2);
-          n1:=Conductor(F1);
-          n12:=PPartOfN(n1,2);
+    g:=DefiningGroupAndCharacterOfCyclotAlg(B1);
+    if g=fail then
+      m2:=1;
+    else
+      m2:=LocalIndexAtPByBrauerCharacter(K,g[1],g[2],2);
+    fi;
+    if not(m2 in Integers) then
+      m:=1;
+      if IsDyadicSchurGroup(g[1]) then
+        m:=2;
+        V:=ValuesOfClassFunction(chi);
+        F0:=FieldByGenerators(V);
+        F1:=B1[2];
+        if not(F0=F1) then
+          if E(4) in F1 then
+            m:=1;
+          else
+            n0:=Conductor(F0);
+            n02:=PPartOfN(n0,2);
+            n1:=Conductor(F1);
+            n12:=PPartOfN(n1,2);
             if not(n02=n12) then
               m:=1;
             else
@@ -1187,14 +1187,14 @@ if Length(B)=5 then
               n01:=PDashPartOfN(n0,2);
               f0:=OrderMod(2,n0);
               f:=f1/f0;
-                if IsPosInt(f/2) then
-                  m:=1;
-                fi;
+              if IsPosInt(f/2) then
+                m:=1;
+              fi;
             fi;
-         fi;
+          fi;
+        fi;
       fi;
     fi;
-  fi;
   fi;
 fi;
 

--- a/lib/div-alg.gi
+++ b/lib/div-alg.gi
@@ -1114,6 +1114,10 @@ fi;
 if Length(B)=5 then
   K:=PSplitSubextension(F,B[3],2);
   B1:=SimpleComponentOfGroupRingByCharacter(K,G,n);
+  if Length(B1)<5 then
+     if Length(B1)=2 then m2:=1; fi;
+     if Length(B1)=4 then m2:=LocalIndexAtTwo(B1); fi;
+  else
   g:=DefiningGroupAndCharacterOfCyclotAlg(B1);
   if g=fail then
     m2:=1;
@@ -1150,6 +1154,7 @@ if Length(B)=5 then
          fi;
       fi;
     fi;
+  fi;
   fi;
 fi;
 

--- a/tst/div-alg.tst
+++ b/tst/div-alg.tst
@@ -87,5 +87,13 @@ gap> List([-2..3],a->LocalIndicesOfRationalSymbolAlgebra(a,7));
 gap> List([-2..3],a->LocalIndicesOfRationalSymbolAlgebra(a,11));
 [ fail, [ [ 2, 2 ], [ 11, 2 ] ], fail, fail, [ [ 2, 2 ], [ 11, 2 ] ], [ [ 2, 2 ], [ 3, 2 ] ] ]
 
+# IsDyadicSchurGroup (PR #104)
+gap> IsDyadicSchurGroup(SmallGroup(8,4));
+true
+gap> IsDyadicSchurGroup(SmallGroup(160,208));
+true
+gap> IsDyadicSchurGroup(SmallGroup(160,84));
+false
+
 #
 gap> STOP_TEST( "div-alg.tst", 1 );


### PR DESCRIPTION
Fixes #103 reported by Thomas Breuer.

The fix provided by @drallenherman who wrote:

> The cause of the problem is that my earlier implementation of this command does not recognize some dyadic Schur groups of type (QD,q) correctly, this causes our current Wedderga to return a 2-local index of 1 for these groups when it should be a 2. I believe the group SmallGroup(272,15) that Thomas Breuer mentioned is the smallest group with this issue.
> The new implementation of the command follows the description of the dyadic Schur groups of type (QD,q) in Riese and Schmid's 1996 paper very precisely, so I'm confident this will fix the problem."