### PR TITLE
Disable checking commutativity of a crossed product

### DIFF
--- a/lib/crossed.gi
+++ b/lib/crossed.gi
@@ -600,11 +600,6 @@ function( R, G, act, twist )
       SetIsFiniteDimensional( RG, IsFinite( G ) );
     fi;
     
-    # What about IsCommutative ? In MagmaRings it is as below:   
-    # if HasIsCommutative( R ) and HasIsCommutative( G ) then
-    #   SetIsCommutative( RG, IsCommutative( R ) and IsCommutative( G ) );
-    # fi;
-    
     if HasIsWholeFamily( R ) and HasIsWholeFamily( G ) then
       SetIsWholeFamily( RG, IsWholeFamily( R ) and IsWholeFamily( G ) );
     fi;
@@ -750,6 +745,17 @@ InstallMethod( IsFinite,
     [ IsCrossedProduct ],
     RG -> IsFinite( LeftActingDomain( RG ) ) and 
           IsFinite( UnderlyingMagma( RG ) ) );
+
+
+#############################################################################
+##
+#M  IsCommutative( <RG> )  . . . . . . . . . . . . . .  for a crossed product
+##
+InstallMethod( IsCommutative,
+    "for a crossed product",
+    [ IsCrossedProduct ],
+    100,
+    RG -> Error("no method found to check commutativity of a crossed product") );
 
 
 #############################################################################

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -81,7 +81,7 @@ gap> WedderburnDecompositionWithDivAlgParts(GroupRing(Rationals, SmallGroup(432,
       rec( Center := NF(27,[ 1, 26 ]), DivAlg := true, 
           LocalIndices := [ [ infinity, 2 ] ], SchurIndex := 2 ) ] ]
 
-# Fix for a bug reported by �ngel del Rio on 14/11/2014
+# Fix for a bug reported by Ángel del Río on 14/11/2014
 gap> G:=SmallGroup(16,7);;
 gap> QG:=GroupRing(Rationals,G);;
 gap> pci := PrimitiveCentralIdempotentsByCharacterTable(QG);;
@@ -104,3 +104,7 @@ gap> A:=[1,CF(7),4,[2,3,2]];
 gap> CyclotomicAlgebraWithDivAlgPart(A);
 [ 1, rec( Center := CF(7), DivAlg := true, LocalIndices := [ [ 2, 2 ] ],
       SchurIndex := 2 ) ]
+
+# Fix returning wrong result determining commutativity of a crossed product (issue #96)
+gap> IsCommutative(WedderburnDecomposition(GroupRing(Rationals, QuaternionGroup(8)))[5]);
+Error, no method found to check commutativity of a crossed product


### PR DESCRIPTION
Alternative version of #105 